### PR TITLE
Create super-linter.yml

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,41 +1,35 @@
-# This workflow executes several linters on changed files based on languages used in your code base whenever
-# you push a code or open a pull request.
-#
-# You can adjust the behavior by modifying this file.
-# For more information, see:
-# https://github.com/github/super-linter
-name: super-linter
+---
+
+name: Lint Code Base
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main]
   pull_request:
-    branches: [ "main" ]
-jobs:
- build:
- 
-  name: Lint Code Base
-   
-  runs-on: ubuntu-latest
-    
+    branches: [main]
 
-permissions:
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+
+    
+    permissions:
       contents: read
       packages: read
       statuses: write
-      
-   
-   
-steps:
-      - name: Checkout code
+
+    
+    steps:
+      - name: Checkout Code
         uses: actions/checkout@v3
         with:
-          # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
+      
       - name: Lint Code Base
-        uses: super-linter/super-linter:slim-v5
+        uses: github/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: "main"
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,41 @@
+# This workflow executes several linters on changed files based on languages used in your code base whenever
+# you push a code or open a pull request.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/github/super-linter
+name: super-linter
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+jobs:
+ build:
+ 
+  name: Lint Code Base
+   
+  runs-on: ubuntu-latest
+    
+
+permissions:
+      contents: read
+      packages: read
+      statuses: write
+      
+   
+   
+steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: super-linter/super-linter:slim-v5
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: "main"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,35 +1,59 @@
 ---
-
+#################################
+#################################
+## Super Linter GitHub Actions ##
+#################################
+#################################
 name: Lint Code Base
 
+#############################
+# Start the job on all push #
+#############################
 on:
   push:
-    branches: [main]
+    branches-ignore: [main]
+    # Remove the line above to run when pushing to master
   pull_request:
     branches: [main]
 
+###############
+# Set the Job #
+###############
 jobs:
   build:
+    # Name the Job
     name: Lint Code Base
+    # Set the agent to run on
     runs-on: ubuntu-latest
 
-    
+    ############################################
+    # Grant status permission for MULTI_STATUS #
+    ############################################
     permissions:
       contents: read
       packages: read
       statuses: write
 
-    
+    ##################
+    # Load all steps #
+    ##################
     steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
+          # Full git history is needed to get a proper
+          # list of changed files within `super-linter`
           fetch-depth: 0
 
-      
+      ################################
+      # Run Linter against code base #
+      ################################
       - name: Lint Code Base
         uses: github/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: main
+          DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Run super-linter:slim-v5 to check the basic consistency of the code style. Will run on push and pull requests to the main branch

Using super-linter slim version 5 to bring down image size by 2GB and speed up the build. For that the following linters are excluded:
- rust linters
- dotenv linters
- armttk linters
- pwsh linters
- c# linters