### PR TITLE
Fix: add empty states in live journey

### DIFF
--- a/app/stores/liveJourney.ts
+++ b/app/stores/liveJourney.ts
@@ -4,6 +4,7 @@ import { Journey } from "./journeys";
 export interface LiveJourney extends Omit<Journey, 'sections'> {
   sections: Array<Journey["sections"][0] | false>;
   isPaused: boolean;
+  isCompleted: boolean;
   currentSection: number;
   currentAction: number;
   currentIntermediateStop: number;

--- a/app/views/liveView/Main.svelte
+++ b/app/views/liveView/Main.svelte
@@ -185,14 +185,22 @@
       let stop = currentSection.intermediateStops[id];
 
       if (currentSection.intermediateStops.length === 0) {
-        return `Steige bei ${currentSection.departure.place.name} in die ${currentSection.transport.name} Richtung ${currentSection.transport.headsign} ein und steige bei ${currentSection.arrival.place.name} wieder aus.`;
+        currentSupportBoxText = `Steige bei ${currentSection.departure.place.name} in die ${currentSection.transport.name} Richtung ${currentSection.transport.headsign} ein und steige bei ${currentSection.arrival.place.name} wieder aus.`;
+      } else {
+        switch (id) {
+          case 0:
+            currentSupportBoxText = `Steige bei ${stop.departure.place.name} in die ${currentSection.transport.name} Richtung ${currentSection.transport.headsign} ein.`;
+            break;
+          case currentSection.intermediateStops.length - 1:
+            currentSupportBoxText = `Gehe zum Ausgang und steige bei ${currentSection.arrival.place.name} aus.`;
+            break;
+          default:
+            currentSupportBoxText = `Du bist im richtigen Transportmittel.`;
+            break;
+        }
       }
 
-      switch (id) {
-        case 0: return `Steige bei ${stop.departure.place.name} in die ${currentSection.transport.name} Richtung ${currentSection.transport.headsign} ein.`;
-        case currentSection.intermediateStops.length - 1: return `Gehe zum Ausgang und steige bei ${currentSection.arrival.place.name} aus.`;
-        default: return `Du bist im richtigen Transportmittel.`;
-      }
+
     } else {
       currentSupportBoxText = `Du musst von {currentSection.departure.place.name} nach {currentSection.arrival.place.name}`;
     }

--- a/app/views/liveView/Main.svelte
+++ b/app/views/liveView/Main.svelte
@@ -2,7 +2,7 @@
   import { navigate, showModal } from "svelte-native";
   import { tick } from 'svelte';
   import { confirm } from '@nativescript/core/ui/dialogs'
-  import { journeys, liveJourney, multiModality } from "~/stores";
+  import { tabIndex, liveJourney, multiModality } from "~/stores";
   import { routeApi,  } from "~/api";
   import { speak } from "~/shared/utils/tts";
   import { playSound } from "~/shared/utils/index";
@@ -54,14 +54,7 @@
 
     // start over again if we reached the end of the journey
     if ($liveJourney.currentSection >= $liveJourney.sections.length - 1) {
-      $liveJourney.currentSection = 0;
-      $liveJourney.currentAction = 0;
-      $liveJourney.currentIntermediateStop = 0;
-
-      if ($multiModality.primary === 'auditory') {
-        await tick();
-        await playAction();
-      }
+      $liveJourney.isCompleted = true;
       return;
     }
 
@@ -231,6 +224,19 @@
         <button text="call" class="icon" on:tap={openContacts} />
         <button text="warning" class="icon" />
       </flexboxLayout>
+
+      {:else if $liveJourney.isCompleted}
+
+      <SupportBox row={0} text="Sehr gut du hast dein Ziel erreicht." type={$multiModality.primary === 'auditory' ? 'big' : 'small'} class="m-b-m" />
+
+      <label text="place" class="icon text-center fs-4xl" on:tap={simulateNextStep} row={1} rowSpan={2}  />
+
+      <gridLayout row="3" columns="*, auto, *" rowSpan={2}>
+          <Button text="Zur Reisen-Übersicht" icon="travel_explore" iconPosition="pre" type="primary" column={1} on:tap={() => {
+            $tabIndex = 0;
+            $liveJourney = null;
+          }} class="m-b-m {$multiModality.primary === 'auditory' ? 'fs-l' : ''}"/>
+      </gridLayout>
 
       {:else}
 

--- a/app/views/liveView/Main.svelte
+++ b/app/views/liveView/Main.svelte
@@ -98,10 +98,13 @@
     if (action === 'depart') return 'start';
     if (action === 'arrive') return 'flag';
     if (action === 'continue') return 'straight';
-    if (action === 'roundaboutExit' && direction === 'left') return 'roundabout_right';
-    if (action === 'roundaboutExit' && direction === 'right') return 'roundabout_left';
+    if (action === 'roundaboutExit' && direction === 'right') return 'roundabout_right';
+    if (action === 'roundaboutExit' && direction === 'left') return 'roundabout_left';
+    if (action === 'roundaboutEnter' && direction === 'right') return 'roundabout_right';
+    if (action === 'roundaboutEnter' && direction === 'left') return 'roundabout_left';
     if (action === 'turn' && direction === 'left') return 'turn_left';
     if (action === 'turn' && direction === 'right') return 'turn_right';
+    console.log('action', action, direction);
     return 'next_plan';
   }
 
@@ -242,22 +245,30 @@
 
           <label text="Karte tbd. Zwischenziel: {currentSection.arrival.place.name ?? currentSection.arrival.place.location.lat + '/' + currentSection.arrival.place.location.lng}" textWrap={true} row={2}  />
 
-        {:else if currentSection.intermediateStops && currentSection.intermediateStops.length > 0}
+        {:else if currentSection.intermediateStops}
 
           <SupportBox row={0} text={(() => {
             let id = $liveJourney.currentIntermediateStop;
             let stop = currentSection.intermediateStops[id];
 
+            if (currentSection.intermediateStops.length === 0) {
+              return `Steige bei ${currentSection.departure.place.name} in die ${currentSection.transport.name} Richtung ${currentSection.transport.headsign} ein und steige bei ${currentSection.arrival.place.name} wieder aus.`;
+            }
+
             switch (id) {
               case 0: return `Steige bei ${stop.departure.place.name} in die ${currentSection.transport.name} Richtung ${currentSection.transport.headsign} ein.`;
               case currentSection.intermediateStops.length - 1: return `Gehe zum Ausgang und steige bei ${currentSection.arrival.place.name} aus.`;
-              default: return `Du bist im richtigen Transportmittel. Noch ${currentSection.intermediateStops.length - $liveJourney.currentIntermediateStop} Haltestellen bis du aussteigen musst.`;
+              default: return `Du bist im richtigen Transportmittel.`;
             }
           })()} type={$multiModality.primary === 'auditory' ? 'big' : 'small'} class="m-b-m" />
 
           <label class="icon text-center fs-3xl" on:tap={simulateNextStep} row={1} text={(() => {
             let id = $liveJourney.currentIntermediateStop;
             let stop = currentSection.intermediateStops[id];
+
+            if (currentSection.intermediateStops.length === 0) {
+              return `${transportTypeToIcon(currentSection.transport.mode)} arrow_forward door_sliding`;
+            }
 
             switch (id) {
               case 0: return `arrow_forward ${transportTypeToIcon(currentSection.transport.mode)}`;
@@ -267,6 +278,13 @@
           })()} />
 
           <label text="train stop {$liveJourney.currentIntermediateStop}" row={2}  />
+        {:else}
+
+          <SupportBox row={0} text="Du musst von {currentSection.departure.place.name} nach {currentSection.arrival.place.name}" type={$multiModality.primary === 'auditory' ? 'big' : 'small'} class="m-b-m" />
+
+          <label text={transportTypeToIcon(currentSection.transport.mode)} class="icon text-center fs-3xl" row={1} on:tap={simulateNextStep} />
+
+          <label text="Karte tbd. Ziel: {currentSection.arrival.place.name ?? currentSection.arrival.place.location.lat + '/' + currentSection.arrival.place.location.lng}" textWrap={true} row={2}  />
 
         {/if}
 

--- a/app/views/planJourney/Main.svelte
+++ b/app/views/planJourney/Main.svelte
@@ -47,6 +47,7 @@
         $liveJourney = {
           ...journey,
           isPaused: false,
+          isCompleted: false,
           currentSection: 0,
           currentAction: 0,
           currentIntermediateStop: 0,


### PR DESCRIPTION
* adds empty states for block with no action or intermediate stop
* adds success screen

depends on #49 